### PR TITLE
Add attr_accessor for original_number

### DIFF
--- a/lib/tracking_number/base.rb
+++ b/lib/tracking_number/base.rb
@@ -1,6 +1,8 @@
 module TrackingNumber
   class Base
     attr_accessor :tracking_number
+    attr_accessor :original_number
+
     def initialize(tracking_number)
       @original_number = tracking_number
       @tracking_number = tracking_number.strip.gsub(" ", "").upcase


### PR DESCRIPTION
Hi, this just adds an accessor for `:original_number`, so you can do something like:

```
TrackingNumber.search(some_text).each do |tracking_number|
  some_text.gsub! /#{tracking_number.original_number}/, tracking_link(tracking_number.tracking_number)
end
```
