### PR TITLE
Fix broken rake Rake::RDocTask call

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,8 +31,8 @@ end
 
 task :default => :test
 
-require 'rake/rdoctask'
-Rake::RDocTask.new do |rdoc|
+require 'rdoc/task'
+RDoc::Task.new do |rdoc|
   $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
   require 'tracking_number'
 


### PR DESCRIPTION
This fix allows the specs to run and pass in both ruby 1.8.7-p371 and 1.9.3-p429
