### PR TITLE
Fedex fix

### DIFF
--- a/lib/tracking_number/fedex.rb
+++ b/lib/tracking_number/fedex.rb
@@ -15,11 +15,12 @@ module TrackingNumber
     end
 
     def valid_checksum?
-      sequence = tracking_number.chars.to_a
-      check = sequence.pop
+      sequence, check_digit = matches
       total = 0
-      sequence.zip([3,1,7,3,1,7,3,1,7,3,1]).collect { |pair| pair[0].to_i * pair[1].to_i }.each { |t| total += t.to_i }
-      return (total % 11 % 10) == check.to_i
+      sequence.chars.to_a.zip([3,1,7,3,1,7,3,1,7,3,1]).each do |(a,b)|
+        total += a.to_i * b
+      end
+      return (total % 11 % 10) == check_digit.to_i
     end
   end
 

--- a/test/fedex_tracking_number_test.rb
+++ b/test/fedex_tracking_number_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class FedExTrackingNumberTest < Test::Unit::TestCase
   context "a FedEx tracking number" do
-    ["986578788855", "477179081230", "799531274483", "790535312317"].each do |valid_number|
+    ["986578788855", "477179081230", "799531274483", "790535312317", "974367662710"].each do |valid_number|
       should "return fedex express for #{valid_number}" do
         should_be_valid_number(valid_number, TrackingNumber::FedExExpress, :fedex)
       end


### PR DESCRIPTION
had a fedex tracking number today where the mod 11 returned 10 and it didn't recognize it as a valid number

http://answers.google.com/answers/threadview/id/207899.html

search bing or google for "974367662710" and it will return a fedex link. Prior to this patch `tracking_number` would return `TrackingNumber::Unknown`
