### PR TITLE
Update USPS rules to support 95… prefix

### DIFF
--- a/lib/tracking_number/usps.rb
+++ b/lib/tracking_number/usps.rb
@@ -6,13 +6,13 @@ module TrackingNumber
   end
 
   class USPS91 < USPS
-    SEARCH_PATTERN = [/(\b9\s*[14]\s*(([0-9]\s*){20,20}\b))/, /(\b([0-9]\s*){20,20}\b)/]
-    VERIFY_PATTERN = /^(9[14][0-9]{19,19})([0-9])$/
+    SEARCH_PATTERN = [/(\b9\s*[145]\s*(([0-9]\s*){20,20}\b))/, /(\b([0-9]\s*){20,20}\b)/]
+    VERIFY_PATTERN = /^(9[145][0-9]{19,19})([0-9])$/
 
     # Sometimes these numbers will appear without the leading 91 or 94, though, so we need to account for that case
 
     def decode
-      # Application ID: 91 or 94
+      # Application ID: 91 or 94 or 95
       # Service Code: 2 Digits
       # Mailer Id: 8 Digits
       # Package Id: 9 Digits
@@ -27,7 +27,7 @@ module TrackingNumber
     end
 
     def matches
-      if self.tracking_number =~ /^9[14]/
+      if self.tracking_number =~ /^9[145]/
         self.tracking_number.scan(VERIFY_PATTERN).flatten
       else
         "91#{self.tracking_number}".scan(VERIFY_PATTERN).flatten
@@ -35,7 +35,7 @@ module TrackingNumber
     end
 
     def valid_checksum?
-      if self.tracking_number =~ /^9[14]/
+      if self.tracking_number =~ /^9[145]/
         return true if weighted_usps_checksum_valid?(tracking_number)
       else
         if weighted_usps_checksum_valid?("91#{self.tracking_number}")

--- a/test/usps_tracking_number_test.rb
+++ b/test/usps_tracking_number_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class USPSTrackingNumberTest < Minitest::Test
   context "a USPS tracking number" do
-    ["9101 1234 5678 9000 0000 13", "7196 9010 7560 0307 7385", "9400 1112 0108 0805 4830 16"].each do |valid_number|
+    ["9101 1234 5678 9000 0000 13", "7196 9010 7560 0307 7385", "9400 1112 0108 0805 4830 16", "9505 5110 6960 5048 6006 24"].each do |valid_number|
       should "return usps with valid 22 digit number: #{valid_number}" do
         should_be_valid_number(valid_number, TrackingNumber::USPS91, :usps)
       end


### PR DESCRIPTION
USPS now has tracking codes that start with 95. Updated library to support this.