### PR TITLE
add support for 26 digit usps tracking numbers that start with 9[1-5]

### DIFF
--- a/lib/tracking_number/usps.rb
+++ b/lib/tracking_number/usps.rb
@@ -6,8 +6,8 @@ module TrackingNumber
   end
 
   class USPS91 < USPS
-    SEARCH_PATTERN = [/(\b(?:420\s*\d{5})?9\s*[1-5]\s*(?:(?:[0-9]\s*){20}\b))/, /(\b([0-9]\s*){20}\b)/]
-    VERIFY_PATTERN = /^(?:420\d{5})?(9[1-5][0-9]{19})([0-9])$/
+    SEARCH_PATTERN = [/(\b(?:420\s*\d{5})?9\s*[1-5]\s*(?:(?:(?:[0-9]\s*){20}\b)|(?:(?:[0-9]\s*){24}\b)))/, /(\b([0-9]\s*){20}\b)/]
+    VERIFY_PATTERN = /^(?:420\d{5})?(9[1-5](?:[0-9]{19}|[0-9]{23}))([0-9])$/
 
     # Sometimes these numbers will appear without the leading 91, 93, or 94, though, so we need to account for that case
 

--- a/test/usps_tracking_number_test.rb
+++ b/test/usps_tracking_number_test.rb
@@ -37,5 +37,11 @@ class USPSTrackingNumberTest < Minitest::Test
         should_be_valid_number(valid_number, TrackingNumber::USPS91, :usps)
       end
     end
+
+    ["92748931507708513018050063"].each do |valid_number|
+      should "return usps with valid 26 digit number: #{valid_number}" do
+        should_be_valid_number(valid_number, TrackingNumber::USPS91, :usps)
+      end
+    end
   end
 end


### PR DESCRIPTION
Couldn't find much info, but this site mentions it: http://www.netforlawyers.com/content/google-no-longer-automatically-recognizes-usps-tracking-numbers

and I've encountered a few tracking numbers like this.