### PR TITLE
Add support for some UPS and USPS test tracking numbers

### DIFF
--- a/lib/tracking_number.rb
+++ b/lib/tracking_number.rb
@@ -15,7 +15,7 @@ if defined?(ActiveModel::EachValidator)
 end
 
 module TrackingNumber
-  TYPES = [UPS, FedExExpress, FedExSmartPost, FedExGround, FedExGround18, FedExGround96, USPS91, USPS20, USPS13, DHLExpress, DHLExpressAir, OnTrac]
+  TYPES = [UPS, UPSTest, FedExExpress, FedExSmartPost, FedExGround, FedExGround18, FedExGround96, USPS91, USPS20, USPS13, USPSTest, DHLExpress, DHLExpressAir, OnTrac]
 
   def self.search(body)
     TYPES.collect { |type| type.search(body) }.flatten

--- a/lib/tracking_number/ups.rb
+++ b/lib/tracking_number/ups.rb
@@ -89,4 +89,20 @@ module TrackingNumber
       end
     end
   end
+
+  class UPSTest < UPS
+    # Easypost UPS test numbers as described here:
+    # https://www.easypost.com/docs/api#tracking (scroll down a bit).
+    SEARCH_PATTERN = /^EZ(\d)00000000\1$/
+    VERIFY_PATTERN = SEARCH_PATTERN
+
+    def matches
+      self.tracking_number.scan(VERIFY_PATTERN).flatten
+    end
+
+    def valid_checksum?
+      sequence = tracking_number.scan(/[a-zA-Z0-9]+/).flatten.join
+      return sequence =~ /EZ(\d)00000000\1/
+    end
+  end
 end

--- a/lib/tracking_number/usps.rb
+++ b/lib/tracking_number/usps.rb
@@ -148,4 +148,19 @@ module TrackingNumber
       return check == check_digit
     end
   end
+
+  class USPSTest < USPS
+    # USPS Test Number From Easypost. IE: 9499 9071 2345 6123 4567 81
+    SEARCH_PATTERN = /(\b([0-9]\s*){22,22}\b)/
+    VERIFY_PATTERN = SEARCH_PATTERN
+
+    def matches
+      self.tracking_number.scan(VERIFY_PATTERN).flatten
+    end
+
+    def valid_checksum?
+      sequence = tracking_number.scan(/[0-9]+/).flatten.join
+      return sequence == "9499907123456123456781"
+    end
+  end
 end

--- a/test/ups_tracking_number_test.rb
+++ b/test/ups_tracking_number_test.rb
@@ -16,4 +16,21 @@ class UPSTrackingNumberTest < Minitest::Test
       end
     end
   end
+
+  context "a UPS test tracking number" do
+    ["EZ1000000001", "EZ2000000002", "EZ3000000003", "EZ4000000004", "EZ5000000005", "EZ6000000006", "EZ7000000007"].each do |valid_number|
+      should "return test for #{valid_number}" do
+        should_be_valid_number(valid_number, TrackingNumber::UPSTest, :ups)
+      end
+
+      should "fail on check digit changes on #{valid_number}" do
+        should_fail_on_check_digit_changes(valid_number)
+      end
+    end
+
+    should "not detect an invalid number" do
+      results = TrackingNumber::UPSTest.search("C10999911320230")
+      assert_equal 0, results.size
+    end
+  end
 end

--- a/test/usps_tracking_number_test.rb
+++ b/test/usps_tracking_number_test.rb
@@ -63,5 +63,11 @@ class USPSTrackingNumberTest < Minitest::Test
         should_fail_on_check_digit_changes(valid_number)
       end
     end
+
+    ["9499907123456123456781", "94999 07123 45612 34567 81"].each do |valid_number|
+      should "return usps with test 22 digit number: #{valid_number}" do
+        should_be_valid_number(valid_number, TrackingNumber::USPSTest, :usps)
+      end
+    end
   end
 end


### PR DESCRIPTION
Added test tracking codes such as these below:

Test Tracking Codes | Tracking Code Status
EZ1000000001	pre_transit
EZ2000000002	in_transit
EZ3000000003	out_for_delivery
EZ4000000004	delivered
EZ5000000005	return_to_sender
EZ6000000006	failure
EZ7000000007	unknown

The above ones come from Easypost but are also UPS test numbers.
https://www.easypost.com/docs/api#tracking

And the USPS 9499907123456123456781 which is standard to USPS.
