### PR TITLE
batch tracker urls

### DIFF
--- a/lib/tracking_number/base.rb
+++ b/lib/tracking_number/base.rb
@@ -35,6 +35,24 @@ module TrackingNumber
       end
     end
 
+    def self.tracking_url(*trackers)
+      if not trackers.all? { |t| t.class == self }
+        raise ArgumentError, "all tracking numbers must be of same class"
+      end
+      url = nil
+      courier = trackers.first.matching_additional["Courier"]
+      if courier
+        url = courier[:tracking_url]
+      else
+        if self.const_defined?(:TRACKING_URL)
+          url = self.const_get(:TRACKING_URL)
+        end
+      end
+      if url
+        url.sub('%s', trackers.map(&:tracking_number).join(','))
+      end
+    end
+
     def serial_number
       return match_group("SerialNumber") unless self.class.const_get("VALIDATION")
 
@@ -170,18 +188,7 @@ module TrackingNumber
     end
 
     def tracking_url
-      url = nil
-      if matching_additional["Courier"]
-        url = matching_additional["Courier"][:tracking_url]
-      else
-        if self.class.const_defined?(:TRACKING_URL)
-          url = self.class.const_get(:TRACKING_URL)
-        end
-      end
-
-      if url
-        url.sub('%s', self.tracking_number)
-      end
+      self.class.tracking_url self
     end
 
     def matching_additional


### PR DESCRIPTION
Include multiple tracking numbers in url. This is based on the assumption that urls accept comma delimited tracking numbers.

did not add any tests (but none fail). Just looking for feedback at this point…

#10 