### PR TITLE
Stop using << to add error message

### DIFF
--- a/lib/tracking_number/active_model_validator.rb
+++ b/lib/tracking_number/active_model_validator.rb
@@ -6,7 +6,7 @@ class TrackingNumberValidator < ActiveModel::EachValidator
     elsif TrackingNumber.new(value).valid?
       # looks good to me
     else
-      record.errors[attribute] << (options[:message] || 'is not a valid tracking number')
+      record.errors.add(attribute, options[:message] || 'is not a valid tracking number')
     end
   end
 end


### PR DESCRIPTION
Rails 6.1 issues a deprecation warning when using "<<" to add an error.
This replaces "<<" with "add" as recommended in the warning:

> DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead.

P.S. I absolutely love this gem, thank you for creating it!