### PR TITLE
Add partner information from tracking_number_data 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ t = TrackingNumber.new("012345000000002")
 t.package_type #=> "case/carton"
 ```
 
+#### Tracking URL
+Get the tracking url from the shipper
+```ruby
+t = TrackingNumber.new("1Z6072AF0320751583")
+t.tracking_url #=> ""https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=1Z6072AF0320751583"
+```
+
+#### All the info we have
+Get a object of all the info we have on the thing
+```ruby
+t = TrackingNumber.new("1Z6072AF0320751583")
+t.info #=>  @courier=#<TrackingNumber::Info:0x000000010a45fed8 @code=:ups, @name="UPS">,
+       #    @decode={:serial_number=>"6072AF032075158", :shipper_id=>"6072AF", :service_type=>"03", :package_id=>"2075158", :check_digit=>"3"},
+       #    @destination_zip=nil,
+       #    @package_type=nil,
+       #    @partners=nil,
+       #    @service_description=nil,
+       #    @service_type="UPS United States Ground",
+       #    @shipper_id="6072AF",
+       #    @tracking_url="https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=1Z6072AF0320751583">
+```
+
 #### Decoding
 Most tracking numbers have a format where each part of the number has meaning. `decode` splits up the number into its known named parts.
 ```ruby
@@ -105,6 +127,29 @@ Most tracking numbers have a format where each part of the number has meaning. `
   #  :package_id => "4683444",
   #  :check_digit => "0"
   # }   
+```
+
+#### Multiple shippers / Partnerships
+Some tracking numbers match multiple carriers, because they belong to multiple carriers. Some shipments like Fedex Smartpost contract the "last mile" out to USPS. 
+
+```ruby
+  # Search defaults to only showing numbers that fulfill the carrier side of the relationship 
+  # (if a partnership exists at all), as this is the end a consumer would most likely be interested in.
+
+  results = TrackingNumber.search('420112139261290983497923666238') 
+  => [#<TrackingNumber::USPS91:0x26ac0 420112139261290983497923666238>]
+
+  tn = results.first
+  tn.shipper? #=> false
+  tn.carrier? #=> true
+  tn.partnership? #=> true
+  tn.partners
+  #=> <struct TrackingNumber::Base::PartnerStruct
+  #       shipper=#<TrackingNumber::FedExSmartPost:0x30624 420112139261290983497923666238>,
+  #       carrier=#<TrackingNumber::USPS91:0x2f1fc 420112139261290983497923666238>>
+
+  tn.partners.shipper #=> #<TrackingNumber::FedExSmartPost:0x30624 420112139261290983497923666238>
+  tn.partners.carrier == tn #=> true
 ```
 
 ## ActiveModel validation

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'tracking_number'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start(__FILE__)

--- a/lib/tracking_number.rb
+++ b/lib/tracking_number.rb
@@ -5,6 +5,7 @@ require 'tracking_number/checksum_validations'
 require 'tracking_number/loader'
 require 'tracking_number/base'
 require 'tracking_number/info'
+require 'tracking_number/partnership'
 require 'tracking_number/unknown'
 require 'active_support/core_ext/string'
 require 'active_support/core_ext/hash'
@@ -16,29 +17,51 @@ end
 TrackingNumber::Loader.load_tracking_number_data
 
 module TrackingNumber
-  def self.search(body)
-    TYPES.collect { |type| type.search(body) }.flatten
+  def self.search(body, match: :carrier)
+    matches = TYPES.collect { |type| type.search(body) }.flatten
+
+    # Some tracking numbers (e.g. Fedex Smartpost) are partnerships between two parties, where one party is the shipper (e.g. Fedex)
+    # and the other party is the [last mile] carrier (e.g. USPS). We're probably interested in the last mile aspect of
+    # the partnership, so by default we'll show those
+
+    # Tracking numbers without a partnership are both the shipper and carrier.
+
+    case match
+    when :carrier
+      matches.filter(&:carrier?)
+    when :shipper
+      matches.filter(&:shipper?)
+    when :all
+      matches
+    else
+      matches
+    end
   end
 
-  def self.detect(tracking_number)
+  def self.detect(tracking_number, match: :carrier)
     tn = nil
-    for test_klass in (TYPES+[Unknown])
+    (TYPES + [Unknown]).each do |test_klass|
       tn = test_klass.new(tracking_number)
-      break if tn.valid?
+      if tn.valid? && (!match || match == :all)
+        break
+      elsif tn.valid? && tn.send("#{match}?")
+        break
+      end
     end
-    return tn
+    tn
   end
 
   def self.detect_all(tracking_number)
     matches = []
-    for test_klass in (TYPES+[Unknown])
+    (TYPES + [Unknown]).each do |test_klass|
       tn = test_klass.new(tracking_number)
       matches << tn if tn.valid?
     end
-    return matches
+
+    matches
   end
 
   def self.new(tracking_number)
-    self.detect(tracking_number)
+    detect(tracking_number)
   end
 end

--- a/lib/tracking_number/base.rb
+++ b/lib/tracking_number/base.rb
@@ -1,15 +1,16 @@
 module TrackingNumber
   class Base
-    attr_accessor :tracking_number
-    attr_accessor :original_number
+    attr_accessor :tracking_number, :original_number, :partner, :partner_data
+
+    PartnerStruct = Struct.new(:shipper, :carrier)
 
     def initialize(tracking_number)
       @original_number = tracking_number
-      @tracking_number = tracking_number.strip.gsub(" ", "").upcase
+      @tracking_number = tracking_number.strip.gsub(' ', '').upcase
     end
 
     def self.search(body)
-      valids = self.scan(body).uniq.collect { |possible| new(possible) }.select { |t| t.valid? }
+      valids = scan(body).uniq.collect { |possible| new(possible) }.select { |t| t.valid? }
 
       uniques = {}
       valids.each do |t|
@@ -23,10 +24,10 @@ module TrackingNumber
       # matches with match groups within the match data
       matches = []
 
-      body.scan(self.const_get(:SEARCH_PATTERN)){
-        #get the match data instead, which is needed with these types of regexes
+      body.scan(const_get(:SEARCH_PATTERN)) do
+        # get the match data instead, which is needed with these types of regexes
         matches << $~
-      }
+      end
 
       if matches
         matches.collect { |m| m[0] }
@@ -36,31 +37,29 @@ module TrackingNumber
     end
 
     def serial_number
-      return match_group("SerialNumber") unless self.class.const_get("VALIDATION")
+      return match_group('SerialNumber') unless self.class.const_get('VALIDATION')
 
       format_info   = self.class.const_get(:VALIDATION)[:serial_number_format]
-      raw_serial    = match_group("SerialNumber")
+      raw_serial    = match_group('SerialNumber')
 
-      if format_info
-        if format_info[:prepend_if] && raw_serial.match(Regexp.new(format_info[:prepend_if][:matches_regex]))
-          return "#{format_info[:prepend_if][:content]}#{raw_serial}"
-        elsif format_info[:prepend_if_missing]
+      if format_info && format_info[:prepend_if] && raw_serial.match(Regexp.new(format_info[:prepend_if][:matches_regex]))
+        return "#{format_info[:prepend_if][:content]}#{raw_serial}"
+      # elsif format_info && format_info[:prepend_if_missing]
 
-        end
       end
 
-      return raw_serial
+      raw_serial
     end
 
     def check_digit
-      match_group("CheckDigit")
+      match_group('CheckDigit')
     end
 
     def decode
       decoded = {}
-      (self.matches.try(:names) || []).each do |name|
+      (matches.try(:names) || []).each do |name|
         sym = name.underscore.to_sym
-        decoded[sym] = self.matches[name]
+        decoded[sym] = matches[name]
       end
 
       decoded
@@ -70,7 +69,8 @@ module TrackingNumber
       return false unless valid_format?
       return false unless valid_checksum?
       return false unless valid_optional_checks?
-      return true
+
+      true
     end
 
     def valid_format?
@@ -78,7 +78,7 @@ module TrackingNumber
     end
 
     def valid_optional_checks?
-      additional_check = self.class.const_get("VALIDATION")[:additional]
+      additional_check = self.class.const_get('VALIDATION')[:additional]
       return true unless additional_check
 
       exist_checks = (additional_check[:exists] ||= [])
@@ -86,8 +86,9 @@ module TrackingNumber
     end
 
     def valid_checksum?
-      return false unless self.valid_format?
-      checksum_info   = self.class.const_get(:VALIDATION)[:checksum]
+      return false unless valid_format?
+
+      checksum_info = self.class.const_get(:VALIDATION)[:checksum]
       return true unless checksum_info
 
       name            = checksum_info[:name]
@@ -97,22 +98,25 @@ module TrackingNumber
     end
 
     def to_s
-      self.tracking_number
+      tracking_number
     end
 
     def inspect
-      "#<%s:%#0x %s>" % [self.class.to_s, self.object_id, tracking_number]
+      format('#<%s:%#0x %s>', self.class.to_s, object_id, tracking_number)
     end
 
     def info
       Info.new({
-        :courier => courier_info,
-        :service_type => service_type,
-        :service_description => service_description,
-        :destination_zip => destination_zip,
-        :shipper_id => shipper_id,
-        :package_type => package_type
-      })
+                 courier: courier_info,
+                 service_type: service_type,
+                 service_description: service_description,
+                 destination_zip: destination_zip,
+                 shipper_id: shipper_id,
+                 package_type: package_type,
+                 tracking_url: tracking_url,
+                 partners: partners,
+                 decode: decode
+               })
     end
 
     def courier_code
@@ -120,68 +124,88 @@ module TrackingNumber
     end
 
     def courier_name
-      if matching_additional["Courier"]
-        matching_additional["Courier"][:courier]
-      else
-        if self.class.constants.include?(:COURIER_INFO)
-          self.class.const_get(:COURIER_INFO)[:name]
-        end
+      if matching_additional['Courier']
+        matching_additional['Courier'][:courier]
+      elsif self.class.constants.include?(:COURIER_INFO)
+        self.class.const_get(:COURIER_INFO)[:name]
       end
     end
 
-    alias_method :carrier, :courier_code #OG tracking_number gem used :carrier.
-    alias_method :carrier_code, :courier_code
-    alias_method :carrier_name, :courier_name
+    alias carrier courier_code # OG tracking_number gem used :carrier.
+    alias carrier_code courier_code
+    alias carrier_name courier_name
 
     def courier_info
-      basics = {:name => courier_name, :code => courier_code}
+      basics = { name: courier_name, code: courier_code }
 
-      if info = matching_additional["Courier"]
-        basics.merge!(:name => info[:courier], :url => info[:courier_url], :country => info[:country])
+      if info = matching_additional['Courier']
+        basics.merge!(name: info[:courier], url: info[:courier_url], country: info[:country])
       end
 
       @courier ||= Info.new(basics)
     end
 
-    def service_type
-      if matching_additional["Service Type"]
-        @service_type ||= Info.new(matching_additional["Service Type"]).name
+    def partnership?
+      partners.present?
+    end
+
+    def shipper?
+      return true unless partnership?
+
+      partners.shipper == self
+    end
+
+    def carrier?
+      return true unless partnership?
+
+      partners.carrier == self
+    end
+
+    def partners
+      return unless self.class.const_defined?(:PARTNERS)
+
+      partner_hash = {}
+
+      return unless (partner_tn = find_matching_partner)
+
+      possible_twin = partner_tn.send(:find_matching_partner)
+      if possible_twin.instance_of?(self.class) && possible_twin.tracking_number == tracking_number
+        partner_hash[partner_data[:partner_type].to_sym] = partner_tn
+        partner_hash[partner_tn.partner_data[:partner_type].to_sym] = self
       end
+
+      PartnerStruct.new(partner_hash[:shipper], partner_hash[:carrier]) if partner_hash.keys.any?
+    end
+
+    def service_type
+      @service_type ||= Info.new(matching_additional['Service Type']).name if matching_additional['Service Type']
     end
 
     def service_description
-      if matching_additional["Service Type"]
-        @service_description ||= Info.new(matching_additional["Service Type"]).description
-      end
+      @service_description ||= Info.new(matching_additional['Service Type']).description if matching_additional['Service Type']
     end
 
     def package_type
-      if matching_additional["Container Type"]
-        @package_type ||= Info.new(matching_additional["Container Type"]).name
-      end
+      @package_type ||= Info.new(matching_additional['Container Type']).name if matching_additional['Container Type']
     end
 
     def destination_zip
-      match_group("DestinationZip")
+      match_group('DestinationZip')
     end
 
     def shipper_id
-      match_group("ShipperId")
+      match_group('ShipperId')
     end
 
     def tracking_url
       url = nil
-      if matching_additional["Courier"]
-        url = matching_additional["Courier"][:tracking_url]
-      else
-        if self.class.const_defined?(:TRACKING_URL)
-          url = self.class.const_get(:TRACKING_URL)
-        end
+      if matching_additional['Courier']
+        url = matching_additional['Courier'][:tracking_url]
+      elsif self.class.const_defined?(:TRACKING_URL)
+        url = self.class.const_get(:TRACKING_URL)
       end
 
-      if url
-        url.sub('%s', self.tracking_number)
-      end
+      url.sub('%s', tracking_number) if url
     end
 
     def matching_additional
@@ -189,21 +213,21 @@ module TrackingNumber
 
       relevant_sections = {}
 
-      additional.each do |info|
-        if self.matches && self.matches.length > 0
-          if value = self.matches[info[:regex_group_name]].gsub(/\s/, "")
-            # has matching value
-            matches = info[:lookup].find do |i|
-              if i[:matches]
-                value == i[:matches]
-              elsif i[:matches_regex]
-                value =~ Regexp.new(i[:matches_regex])
-              end
-            end
+      additional.each do |additional_info|
+        next unless matches && matches.length > 0 # skip if no match groups
+        value = matches[additional_info[:regex_group_name]].gsub(/\s/, '') # match is empty
+        next unless value
 
-            relevant_sections[info[:name]] = matches
+        matches = additional_info[:lookup].find do |i|
+          if i[:matches]
+            value == i[:matches]
+          elsif i[:matches_regex]
+            value =~ Regexp.new(i[:matches_regex])
           end
         end
+
+        # has matching value
+        relevant_sections[additional_info[:name]] = matches
       end
 
       relevant_sections
@@ -211,21 +235,78 @@ module TrackingNumber
 
     protected
 
-    def matches
-      if self.class.constants.include?(:VERIFY_PATTERN)
-        self.tracking_number.match(self.class.const_get(:VERIFY_PATTERN))
-      else
-        []
+    def match_all(items)
+      items.all? do |i|
+        if i[:matches] && matches[i[:regex_group_name]]
+          matches[i[:regex_group_name]] == i[:matches]
+        elsif i[:matches_regex] && matches[i[:regex_group_name]]
+          matches[i[:regex_group_name]] =~ Regexp.new(i[:matches_regex])
+        else
+          false
+        end
       end
+    end
+
+    def match_any(items)
+      items.find do |i|
+        if i[:matches] && matches[i[:regex_group_name]]
+          matches[i[:regex_group_name]] == i[:matches]
+        elsif i[:matches_regex] && matches[i[:regex_group_name]]
+          matches[i[:regex_group_name]] =~ Regexp.new(i[:matches_regex])
+        else
+          false
+        end
+      end
+    end
+
+    def matches
+      @matches ||= if self.class.constants.include?(:VERIFY_PATTERN)
+                     tracking_number.match(self.class.const_get(:VERIFY_PATTERN))
+                   else
+                     []
+                   end
     end
 
     def match_group(name)
-      begin
-        self.matches[name].gsub(/\s/, '')
-      rescue
-        nil
-      end
+      matches[name].gsub(/\s/, '')
+    rescue StandardError
+      nil
     end
 
+    def find_matching_partner
+      partner_info = self.class.const_get(:PARTNERS) || []
+
+      partner_info.each do |partner_data|
+        klass = find_tracking_class_by_id(partner_data[:partner_id])
+
+        return false unless klass
+
+        tn = klass.new(tracking_number)
+
+        valid = if partner_data.dig(:validation, :matches_all)
+                  tn.valid? && match_all(partner_data.dig(:validation, :matches_all))
+                elsif partner_data.dig(:validation, :matches_any)
+                  tn.valid? && match_any(partner_data.dig(:validation, :matches_any))
+                else
+                  tn.valid?
+                end
+
+        next unless valid
+
+        @partner = tn
+        @partner_data = partner_data
+        break
+      end
+
+      return @partner
+    end
+
+    def find_tracking_class_by_id(id)
+      return unless id
+
+      TrackingNumber::TYPES.detect do |type|
+        type.const_get('ID') == id
+      end
+    end
   end
 end

--- a/lib/tracking_number/loader.rb
+++ b/lib/tracking_number/loader.rb
@@ -1,22 +1,21 @@
-
 module TrackingNumber
   module Loader
     class << self
-      def load_tracking_number_data(couriers_path = File.join(File.dirname(__FILE__), "../data/couriers/"))
+      def load_tracking_number_data(couriers_path = File.join(File.dirname(__FILE__), '../data/couriers/'))
         mapping_data = []
         tracking_number_types = []
         Dir.glob(File.join(couriers_path, '/*.json')).each do |file|
-          courier_info          = read_courier_info(file)
+          courier_info = read_courier_info(file)
 
           courier_info[:tracking_numbers].each do |tracking_info|
-            tracking_name = tracking_info[:name]
-            klass         = create_class(klass, courier_info, tracking_info)
+            klass = create_class(courier_info, tracking_info)
 
             # Do some basic checks on the data file
             throw 'missing test numbers' unless has_test_numbers?(tracking_info)
-            throw 'missing regex match groups' unless test_numbers_return_required_groups?(tracking_info, Regexp.new(klass::VERIFY_PATTERN))
+            throw 'missing regex match groups' unless test_numbers_return_required_groups?(tracking_info,
+                                                                                           Regexp.new(klass::VERIFY_PATTERN))
+            const = register_class(klass, tracking_info[:name])
 
-            const = register_class(klass, tracking_name)
             tracking_number_types.push(const)
             mapping_data << {
               class: const,
@@ -28,33 +27,33 @@ module TrackingNumber
         end
 
         TrackingNumber.const_set('TYPES', tracking_number_types)
-        
-        return mapping_data
+
+        mapping_data
       end
 
       private
 
       def has_test_numbers?(tracking)
-        return tracking[:test_numbers] && tracking[:test_numbers][:valid]
+        tracking[:test_numbers] && tracking[:test_numbers][:valid]
       end
 
       def test_numbers_return_required_groups?(tracking, regex)
         test_number = tracking[:test_numbers][:valid][0]
         matches = test_number.match(regex)
 
-        return matches["SerialNumber"]
+        matches['SerialNumber']
       end
 
       def read_courier_info(file)
-        return JSON.parse(File.read(file)).deep_symbolize_keys!
+        JSON.parse(File.read(file)).deep_symbolize_keys!
       end
 
-      def create_class(klass, courier_info, tracking_info)
+      def create_class(courier_info, tracking_info)
         klass = Class.new(TrackingNumber::Base)
-        klass.const_set("COURIER_CODE", courier_info[:courier_code])
+        klass.const_set('COURIER_CODE', courier_info[:courier_code])
         info = courier_info.dup
         info.delete(:tracking_numbers)
-        klass.const_set("COURIER_INFO", info)
+        klass.const_set('COURIER_INFO', info)
 
         pattern = tracking_info[:regex]
         pattern = tracking_info[:regex].join if tracking_info[:regex].is_a?(Array)
@@ -62,19 +61,21 @@ module TrackingNumber
         verify_pattern = "^#{pattern}$"
         search_pattern = "\\b#{pattern}\\b"
 
-        klass.const_set("SEARCH_PATTERN", Regexp.new(search_pattern))
-        klass.const_set("VERIFY_PATTERN", Regexp.new(verify_pattern))
+        klass.const_set('SEARCH_PATTERN', Regexp.new(search_pattern))
+        klass.const_set('VERIFY_PATTERN', Regexp.new(verify_pattern))
 
-        klass.const_set("VALIDATION", tracking_info[:validation])
-        klass.const_set("ADDITIONAL", tracking_info[:additional])
-        klass.const_set("TRACKING_URL", tracking_info[:tracking_url])
+        klass.const_set('VALIDATION', tracking_info[:validation])
+        klass.const_set('ADDITIONAL', tracking_info[:additional])
+        klass.const_set('TRACKING_URL', tracking_info[:tracking_url])
+        klass.const_set('PARTNERS', tracking_info[:partners])
+        klass.const_set('ID', tracking_info[:id])
 
-        return klass
+        klass
       end
 
       def register_class(klass, tracking_name)
         klass_name = tracking_name.gsub(/[^0-9A-Za-z]/, '')
-        return TrackingNumber.const_set(klass_name, klass)
+        TrackingNumber.const_set(klass_name, klass)
       end
     end
   end

--- a/lib/tracking_number/partnership.rb
+++ b/lib/tracking_number/partnership.rb
@@ -1,0 +1,7 @@
+module TrackingNumber
+  class Partnership
+    def initialize(tracking_numbers)
+      
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,8 +18,6 @@ class Minitest::Test
     possible_numbers = []
     possible_numbers << tracking
     possible_numbers << tracking.to_s.gsub(" ", "")
-    possible_numbers << tracking.chars.to_a.join(" ")
-    possible_numbers << tracking.chars.to_a.join("  ")
     possible_numbers << tracking.slice(0, (tracking.length / 2)) + "  " + tracking.slice((tracking.length / 2), tracking.length)
 
     possible_numbers.flatten.uniq

--- a/test/tracking_number_meta_test.rb
+++ b/test/tracking_number_meta_test.rb
@@ -23,7 +23,7 @@ class TrackingNumberMetaTest < Minitest::Test
         tracking_info[:test_numbers][:valid].each do |valid_number|
           should "detect #{valid_number} as #{klass_name}" do
             #TODO fix this multiple matching thing
-            matches = TrackingNumber.search(valid_number)
+            matches = TrackingNumber.search(valid_number, match: :all)
             assert matches.collect(&:class).include?(klass)
           end
 


### PR DESCRIPTION
Certain shipments (e.g. FedEx SmartPost) are shared between shipping couriers, and previously a number like`420112139261290983497923666238` would return both a `FedExSmartPost` number and a `USPS91` number and return both to the consumer. This wasn't wrong, but it wasn't the complete answer either. 

[tracking_number_data v1.5](https://github.com/jkeen/tracking_number_data) now models two-way partnerships, where one party is the `shipper` (FedEx in this example), and the other party is the `carrier` (USPS). Most often a carrier (say, UPS) will handle the entire journey, but this change now handles the exceptional case nicely.

## Changes:

New methods have been added to `TrackingNumber` instances, namely: 

`partnership?` => Does this number have a companion with another service?
`shipper?` => Is this information regarding the shipper of this package? (true if not a partnership)
`carrier?` => Is this information referring to the carrier of this package? (true if not a partnership)
`partners` => Returns a struct containing a `shipper` key and a `carrier` key, each containing an instance of tracking number for each part of the relationship.

Along with this change, `TrackingNumber.search` now defaults to only showing numbers that fulfill the _carrier_ side of the relationship (if a partnership exists at all), as this is the end a consumer would most likely be interested in. This resolves the detection issues reported in #70, and [here](https://github.com/jkeen/tracking_number_data/issues/12) and [here](https://github.com/jkeen/tracking_number_data/issues/23), etc.

## Examples:

```ruby 
results = TrackingNumber.search('420112139261290983497923666238') 
=> [#<TrackingNumber::USPS91:0x26ac0 420112139261290983497923666238>]

tn = results.first
tn.shipper? #=> false
tn.carrier? #=> true
tn.partnership? #=> true
tn.partners
 #=> <struct TrackingNumber::Base::PartnerStruct
 #       shipper=#<TrackingNumber::FedExSmartPost:0x30624 420112139261290983497923666238>,
 #       carrier=#<TrackingNumber::USPS91:0x2f1fc 420112139261290983497923666238>>

tn.partners.shipper #=> #<TrackingNumber::FedExSmartPost:0x30624 420112139261290983497923666238>
tn.partners.carrier == tn #=> true
```
To return both the shipper and carrier when searching, you can pass a second argument into search:

```ruby
results = TrackingNumber.search('420112139261290983497923666238', match: :all) 
#=> [<TrackingNumber::FedExSmartPost:0x30624 420112139261290983497923666238>, <TrackingNumber::USPS91:0x2f1fc 420112139261290983497923666238>]
```

TrackingNumbers that are not a partnership fulfill both sides of the relationship and indicate as such:
```ruby
tn = TrackingNumber.new('1Z879E930346834440')

tn.shipper? #=> true
tn.carrier? #=> true
tn.partnership? #=> false
tn.partners #=> nil
```


refs: https://github.com/jkeen/tracking_number_data/pull/84