### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/tracking_number.gemspec
+++ b/tracking_number.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('activemodel', '> 4.2.5.1')
   s.add_development_dependency('minitest', '~> 5.5')
   s.add_development_dependency('minitest-reporters', '~> 1.1')
-  s.add_development_dependency('rake', '~> 10.4.2')
+  s.add_development_dependency('rake', '~> 13.0')
   s.add_development_dependency('shoulda')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('terminal-table')


### PR DESCRIPTION
Updated the Rake development dependency to allow Ruby 3.2 to run.