### PR TITLE
Upcase body before searching to find lowercase tracking numbers

### DIFF
--- a/lib/tracking_number/base.rb
+++ b/lib/tracking_number/base.rb
@@ -24,7 +24,7 @@ module TrackingNumber
       # matches with match groups within the match data
       matches = []
 
-      body.scan(const_get(:SEARCH_PATTERN)) do
+      body.upcase.scan(const_get(:SEARCH_PATTERN)) do
         # get the match data instead, which is needed with these types of regexes
         matches << $~
       end

--- a/test/tracking_number_test.rb
+++ b/test/tracking_number_test.rb
@@ -40,6 +40,12 @@ class TrackingNumberTest < Minitest::Test
       assert_equal 1, s.size
       assert_equal "1Z879E930346834440", s.first.tracking_number
     end
+
+    should "return tracking numbers entered as lowercase" do
+      s = TrackingNumber.search("hello 1z879E930346834440 bye")
+      assert_equal 1, s.size
+      assert_equal "1Z879E930346834440", s.first.tracking_number
+    end
   end
 
   context "tracking number additional data for ups" do
@@ -201,7 +207,7 @@ class TrackingNumberTest < Minitest::Test
   context "searching numbers that have partners" do
     partnership_number = "420 11213 92 6129098349792366623 8"
     single_number = "92001903060085300042901077"
-  
+
     search_string = ["number that matches two services", partnership_number, " number that matches only one: ", single_number, "let's see if that does it"].join(' ')
 
     should "match only carriers by default" do


### PR DESCRIPTION
The regexps define the search pattern in terms of uppercase characters, so when the source data you're searching contains lowercase tracking numbers, they don't match.

By upcasing the body before searching, it's more likely to match the search patterns.

This also matches that initializing a new `TrackingNumber` object upcases the number for its internal value.

Inspired by:
https://github.com/jkeen/tracking_number_data/pull/102

Meant as an interim solution until it's decided whether the source regexps should be case-sensitive or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced tracking number detection by allowing case-insensitive search, improving user experience when entering tracking numbers in various formats.

- **Tests**
  - Added a test case to verify the functionality of case-insensitive tracking number recognition, ensuring reliability and accuracy in diverse input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->