### PR TITLE
Removed boilerplate executable from published gem

### DIFF
--- a/tracking_number.gemspec
+++ b/tracking_number.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |s|
 
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
   s.homepage = 'http://github.com/jkeen/tracking_number'
   s.licenses = ['MIT']


### PR DESCRIPTION
👋  I found `tracking_number` gem contained `console` executable generated by `bundle gem` for published gem. It will be installed `PATH` directory. I'm bit of surprised that behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the gem’s configuration to remove the automatic inclusion of command-line tools.
  - Command-line functionality now requires explicit configuration if needed, while all other aspects remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->